### PR TITLE
Allow uppercase HR data path

### DIFF
--- a/src/js/settings/pages/SettingsPageHeartRate.tsx
+++ b/src/js/settings/pages/SettingsPageHeartRate.tsx
@@ -113,7 +113,7 @@ export const SettingsPageHeartRate: FC = () => {
                 autoComplete="off"
                 value={pathInputValue}
                 onChange={handlePathInputChange}
-                pattern="^[a-z\d_.-]+$"
+                pattern="^[a-zA-Z\d_.-]+$"
                 placeholder="Enter path in JSON data (optional)"
             />
         </details>

--- a/src/js/utils/settings.ts
+++ b/src/js/utils/settings.ts
@@ -17,7 +17,7 @@ export const settingValidators: { [k in SettingName]: (input: unknown) => Settin
         return null;
     },
     [SettingName.HEART_RATE_WEBSOCKET_PATH]: input => {
-        if (typeof input === 'string' && /^[a-z\d_.-]+$/.test(input)) {
+        if (typeof input === 'string' && /^[a-zA-Z\d_.-]+$/.test(input)) {
             return input;
         }
         return null;


### PR DESCRIPTION
Example: `data.heartRate`

It's currently possible to set it in chrome, export it as base64, and import it in OBS. But the validation on reload removes the value again.